### PR TITLE
xterm: parse most significant digits

### DIFF
--- a/src/xterm.rs
+++ b/src/xterm.rs
@@ -31,9 +31,9 @@ pub fn query_bg_color() -> Result<Rgb, TlError> {
     match s.strip_prefix("\x1b]11;rgb:") {
         Some(raw_color) if raw_color.len() >= 14 => {
             Ok(Rgb::new(
-                u8::from_str_radix(&raw_color[2..4], 16)?,
-                u8::from_str_radix(&raw_color[7..9], 16)?,
-                u8::from_str_radix(&raw_color[12..14], 16)?,
+                u8::from_str_radix(&raw_color[0..2], 16)?,
+                u8::from_str_radix(&raw_color[5..7], 16)?,
+                u8::from_str_radix(&raw_color[10..12], 16)?,
             ))
         }
         _ => Err(TlError::WrongFormat(s.to_string()))


### PR DESCRIPTION
each component of the rgb color response can have 1-4 hex digits[1]
and some terminals actually use that color space
for example gnome console (kgx) 43.0 in dark mode reports:

    ; printf '\\x1b]11;?\\x07'
    ]11;rgb:1eb8/1eb8/1eb8

in 8bit rgb this is closest to #1e1e1e
but the current code parses it as #b8b8b8
and calculates the wrong luma:

    ; cargo run 2>/dev/null
    0.71875

this change makes the parsing more accurate by using the most significant digits instead of the least significant ones
the resulting luma is much more accurate:

    ; cargo run
    0.1171875

and luma calculated for other terminals i have on hand stayed the same

this calculation is still not really *correct*
since we ignore the other digits
and don't handle 1-3 digits at all,
but modern terminals all seem to use 4 digits anyway

nb: i assume the behavior mentioned in the code comment
(that the first two digits get repeated)
is done so colors don't get "rounded down" towards dark
by applications that really use the whole 16 bit space

[1]: https://man.openbsd.org/XParseColor.3#COLOR_NAMES
